### PR TITLE
[REFM] removed Banco Lopez de Haro

### DIFF
--- a/models/res_company.py
+++ b/models/res_company.py
@@ -33,7 +33,6 @@ class ResCompany(models.Model):
     l10n_do_currency_provider = fields.Selection([
         ('bpd', 'Banco Popular Dominicano'),
         ('bnr', 'Banco de Reservas'),
-        ('blh', 'Banco Lopez de Haro'),
         ('bpr', 'Banco del Progreso'),
         ('bsc', 'Banco Santa Cruz'),
         ('bdi', 'Banco BDI'),

--- a/static/description/index.html
+++ b/static/description/index.html
@@ -18,7 +18,6 @@
                 <ul style="list-style-type:none">
                     <li><h2 class="oe_mt32">Banco Popular Dominicano</h2></li>
                     <li><h2 class='oe_mt32'>Banco de Reservas</h2></li>
-                    <li><h2 class='oe_mt32'>Banco Lopez de Haro</h2></li>
                     <li><h2 class='oe_mt32'>Banco del Progreso</h2></li>
                     <li><h2 class='oe_mt32'>Banco Santa Cruz</h2></li>
                     <li><h2 class='oe_mt32'>Banco BDI</h2></li>

--- a/tests/test_currency_update.py
+++ b/tests/test_currency_update.py
@@ -35,17 +35,6 @@ class CurrencyTestCase(TransactionCase):
         self.assertTrue(res)
         self.assertEqual(len(self.currency_usd.rate_ids), rates_count + 1)
 
-    def test_l10n_do_currency_update_blh(self):
-        """ Banco Lopez de Haro currency update test """
-
-        self.test_company.l10n_do_currency_provider = 'blh'
-        self.test_company.currency_base = 'buyrate'
-        self.test_company.currency_service_token = 'demotoken'
-        rates_count = len(self.currency_usd.rate_ids)
-        res = self.test_company.l10n_do_update_currency_rates()
-        self.assertTrue(res)
-        self.assertEqual(len(self.currency_usd.rate_ids), rates_count + 1)
-
     def test_l10n_do_currency_update_bpr(self):
         """ Banco del Progreso currency update test """
 


### PR DESCRIPTION
Removed because API stopped updating BLH currency rates data due to BLH website request wrong headers values.