### PR TITLE
[FIX] l10n_do_rnc_validation: do not log any message

### DIFF
--- a/l10n_do_rnc_validation/models/res_partner.py
+++ b/l10n_do_rnc_validation/models/res_partner.py
@@ -147,13 +147,8 @@ class ResPartner(models.Model):
                 except:
                     pass
                 if dgii_vals is None:
-                    if is_rnc:
-                        self.sudo().message_post(
-                            subject=_("%s vat request" % self.name),
-                            body=_("External service could not find requested "
-                                   "contact data."))
                     result['vat'] = number
-                elif dgii_vals:
+                else:
                     result['name'] = dgii_vals.get('name', False)
                     result['vat'] = dgii_vals.get('rnc')
                     if model == 'res.partner':


### PR DESCRIPTION
Durante la creación de un contacto, si el servicio externo no retorna datos, puede ocurrir un error al momento de logear un mensaje en el nuevo contacto con la función `message_post()`, ya que esta necesita un record en el cual ejecutarse, y la función que la llama (`validate_rnc_cedula()`) es un _class function_, por lo que no se espera que exista un record.