### PR TITLE
[FIX] l10n_do_rnc_validation: IntegrityError

### DIFF
--- a/l10n_do_rnc_validation/data/ir_config_parameter_data.xml
+++ b/l10n_do_rnc_validation/data/ir_config_parameter_data.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
 
-    <record id="l10n_do_rnc_validation_api_url" model="ir.config_parameter">
+    <record id="l10n_do_rnc_validation_api_url" model="ir.config_parameter" forcecreate="0">
         <field name="key">rnc.indexa.api.url</field>
         <field name="value">https://api.indexa.do/api/rnc</field>
     </record>
 
-    <record id="l10n_do_rnc_validation_api_token" model="ir.config_parameter">
+    <record id="l10n_do_rnc_validation_api_token" model="ir.config_parameter" forcecreate="0">
         <field name="key">rnc.indexa.api.token</field>
         <field name="value">false</field>
     </record>


### PR DESCRIPTION
duplicate key value violates unique constraint "ir_config_parameter_key_uniq" DETAIL: Key (key)=(indexa.api.token) already exists.