### PR TITLE
[13.0][IMP] l10n_do_ecf_invoicing: save signed ecf

### DIFF
--- a/l10n_do_ecf_invoicing/__manifest__.py
+++ b/l10n_do_ecf_invoicing/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Indexa",
     "website": "https://www.indexa.do",
     "category": "Accounting",
-    "version": "13.0.1.2.3",
+    "version": "13.0.1.3.3",
     "depends": ["l10n_do_accounting", "l10n_do_debit_note"],
     "data": [
         "views/account_views.xml",

--- a/l10n_do_ecf_invoicing/models/account_move.py
+++ b/l10n_do_ecf_invoicing/models/account_move.py
@@ -2,6 +2,7 @@
 #  See LICENSE file for full licensing details.
 
 import ast
+import base64
 import requests
 from datetime import datetime as dt
 from collections import OrderedDict as od
@@ -725,7 +726,7 @@ class AccountMove(models.Model):
                         {
                             "TipoSubDescuento": "%",
                             "SubDescuentoPorcentaje": line.discount,
-                            "MontoSubDescuento": discount_amount
+                            "MontoSubDescuento": discount_amount,
                         }
                     ]
                 }
@@ -969,6 +970,10 @@ class AccountMove(models.Model):
                     vals = ast.literal_eval(response_text)
                     status = vals.get("status", False)
 
+                    ecf_xml = b""
+                    if "xml" in vals:
+                        ecf_xml += str(vals["xml"]).encode("utf-8")
+
                     if status:
                         status = status.replace(" ", "")
                         sign_datetime = vals.get("signature_datetime", False)
@@ -990,6 +995,8 @@ class AccountMove(models.Model):
                                         "security_code"
                                     ),
                                     "l10n_do_ecf_sign_date": strp_sign_datetime,
+                                    "l10n_do_ecf_edi_file_name": "%s.xml" % invoice.ref,
+                                    "l10n_do_ecf_edi_file": base64.b64encode(ecf_xml),
                                 }
                             )
 

--- a/l10n_do_ecf_invoicing/views/account_views.xml
+++ b/l10n_do_ecf_invoicing/views/account_views.xml
@@ -10,6 +10,10 @@
                 <field name="l10n_do_ecf_expecting_payment" invisible="1"/>
             </field>
             <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="l10n_do_ecf_edi_file" filename="l10n_do_ecf_edi_file_name"
+                       attrs="{'invisible': [('l10n_do_ecf_edi_file', '=', False)]}"
+                       groups="base.group_no_one"/>
+                <field name="l10n_do_ecf_edi_file_name" invisible="1"/>
                 <label for="l10n_do_ecf_send_state" invisible="1"/>
                 <div class="o_row" col="4">
                     <field name="l10n_do_ecf_send_state"


### PR DESCRIPTION
Por normativa de la DGII, se debe guardar cada XML firmado de las facturas electrónicas enviadas.