### PR TITLE
[13.0][IMP] l10n_do_ecf_invoicing: log Conditionally Accepted message when updating ecf sending status

### DIFF
--- a/l10n_do_ecf_invoicing/__manifest__.py
+++ b/l10n_do_ecf_invoicing/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Indexa",
     "website": "https://www.indexa.do",
     "category": "Accounting",
-    "version": "13.0.1.9.5",
+    "version": "13.0.1.9.6",
     "depends": ["l10n_do_accounting", "l10n_do_debit_note"],
     "data": [
         "views/account_views.xml",

--- a/l10n_do_ecf_invoicing/models/account_move.py
+++ b/l10n_do_ecf_invoicing/models/account_move.py
@@ -1077,9 +1077,15 @@ class AccountMove(models.Model):
                     status = vals.get("estado", "EnProceso").replace(" ", "")
                     if status in ECF_STATE_MAP:
                         invoice.l10n_do_ecf_send_state = ECF_STATE_MAP[status]
-                        if invoice.l10n_do_ecf_send_state == "delivered_refused":
+                        if ECF_STATE_MAP[status] in (
+                            "delivered_refused",
+                            "conditionally_accepted",
+                        ):
                             invoice.log_error_message(response_text)
-                            invoice.with_context(cancelled_by_dgii=True).button_cancel()
+                            if ECF_STATE_MAP[status] == "delivered_refused":
+                                invoice.with_context(
+                                    cancelled_by_dgii=True
+                                ).button_cancel()
                     else:
                         continue
 


### PR DESCRIPTION
Tras enviar un ECF y recibir el estado "delivered_pending", este estado es actualizado por una función llamada desde un cron.

Cuando el nuevo estado se recibe, y este estado es "conditionally_accepted", no se estaban logeando los mensajes que envía la DGII.

Este PR aplica una mejora de manera que en estos casos también se registren los mensajes de la DGII.