### PR TITLE
[13.0][IMP] l10n_do_ecf_invoicing: flush models to prevent pending transactions

### DIFF
--- a/l10n_do_ecf_invoicing/__manifest__.py
+++ b/l10n_do_ecf_invoicing/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Indexa",
     "website": "https://www.indexa.do",
     "category": "Accounting",
-    "version": "13.0.1.20.19",
+    "version": "13.0.1.21.19",
     "depends": ["l10n_do_accounting", "l10n_do_debit_note"],
     "data": [
         "views/account_views.xml",

--- a/l10n_do_ecf_invoicing/models/account_move.py
+++ b/l10n_do_ecf_invoicing/models/account_move.py
@@ -1020,6 +1020,9 @@ class AccountMove(models.Model):
 
         for invoice in self:
 
+            self.flush()
+            self.env["ir.sequence"].flush()
+
             if invoice.l10n_do_ecf_send_state in (
                 "delivered_accepted",
                 "conditionally_accepted",
@@ -1278,15 +1281,16 @@ class AccountMove(models.Model):
 
     def post(self):
 
-        res = super(AccountMove, self).post()
+        posted = super(AccountMove, self).post()
 
-        fiscal_invoices = self.filtered(
-            lambda i: i.is_l10n_do_internal_sequence
-            and i.is_ecf_invoice
-            and i.l10n_do_ecf_send_state == "to_send"
-            and i._do_immediate_send()
-        )
-        fiscal_invoices.send_ecf_data()
-        fiscal_invoices._compute_l10n_do_electronic_stamp()
+        if posted:
+            fiscal_invoices = self.filtered(
+                lambda i: i.is_l10n_do_internal_sequence
+                and i.is_ecf_invoice
+                and i.l10n_do_ecf_send_state == "to_send"
+                and i._do_immediate_send()
+            )
+            fiscal_invoices.send_ecf_data()
+            fiscal_invoices._compute_l10n_do_electronic_stamp()
 
-        return res
+        return posted


### PR DESCRIPTION
Este PR tiene la intención de solventar el issue de que se dupliquen las secuencias de comprobantes fiscales electrónicos enviados a la DGII.

Se implementa la llamada de la función [flush()](https://www.odoo.com/documentation/13.0/developer/reference/addons/orm.html?highlight=flush#odoo.models.Model.flush), con la cual buscamos que se complete el cómputo y actualización de base de datos (específicamente las tablas **account_move** e **ir_sequence**) antes del procesamiento y posterior envío de una factura electrónica a la DGII.

Nota:
¿Por qué `flush()` y no `commit()`?
Por esto: https://www.odoo.com/forum/help-1/difference-between-self-flush-and-self-env-cr-commit-194142